### PR TITLE
Fixed constants path error

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,3 @@
+declare module '@multiversx/sdk-dapp/out/constants/window.constants.mjs' {
+    export const safeWindow: typeof window;
+  }

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,3 +1,0 @@
-declare module '@multiversx/sdk-dapp/out/constants/window.constants.mjs' {
-    export const safeWindow: typeof window;
-  }

--- a/src/lib/sdkCore.ts
+++ b/src/lib/sdkCore.ts
@@ -17,5 +17,3 @@ export {
   UserSecretKey,
   UserSigner
 } from '@multiversx/sdk-core';
-
-export { safeWindow } from '@multiversx/sdk-dapp/out/constants/window.constants.mjs';

--- a/src/lib/sdkCore.ts
+++ b/src/lib/sdkCore.ts
@@ -18,4 +18,4 @@ export {
   UserSigner
 } from '@multiversx/sdk-core';
 
-export { safeWindow } from '@multiversx/sdk-dapp/out/constants';
+export { safeWindow } from '@multiversx/sdk-dapp/out/constants/window.constants.mjs';

--- a/src/lib/sdkDapp/sdkDapp.constants.ts
+++ b/src/lib/sdkDapp/sdkDapp.constants.ts
@@ -8,3 +8,5 @@ export {
   GAS_PRICE,
   VERSION
 } from '@multiversx/sdk-dapp/out/constants/mvx.constants';
+
+export { safeWindow } from '@multiversx/sdk-dapp/out/constants/window.constants';


### PR DESCRIPTION
Fixed the import path for `safeWindow`. The integration test from `sdk-dapp` was failing because of this.